### PR TITLE
PulseAudio fixups

### DIFF
--- a/mplugd/header.py
+++ b/mplugd/header.py
@@ -143,7 +143,7 @@ class MP_object(object):
 		try:
 			val = self.get_attr(self._obj, attr)
 		except dbus.exceptions.DBusException:
-			raise AttributeError("%r object has no attribute %r" % (type(s    elf).__name__, attr))
+			raise AttributeError("%r object has no attribute %r" % (type(self).__name__, attr))
 		if val != None:
 			return val
 		

--- a/mplugd/header.py
+++ b/mplugd/header.py
@@ -142,7 +142,7 @@ class MP_object(object):
 		# query PA over dbus if it knows the attribute
 		try:
 			val = self.get_attr(self._obj, attr)
-		except dbus.exceptions.DBusException:
+		except AttributeError:
 			raise AttributeError("%r object has no attribute %r" % (type(self).__name__, attr))
 		if val != None:
 			return val

--- a/mplugd/header.py
+++ b/mplugd/header.py
@@ -140,7 +140,10 @@ class MP_object(object):
 			raise AttributeError("%r object has no attribute %r" % (type(self).__name__, attr))
 		
 		# query PA over dbus if it knows the attribute
-		val = self.get_attr(self._obj, attr)
+		try:
+			val = self.get_attr(self._obj, attr)
+		except dbus.exceptions.DBusException:
+			raise AttributeError("%r object has no attribute %r" % (type(s    elf).__name__, attr))
 		if val != None:
 			return val
 		

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -361,11 +361,8 @@ class Stream(PA_object):
 				return self._props["application.name"][:-1]
 			elif "device.description" in self._props:
 				return self._props["device.description"][:-1]
-		try:
-			return PA_object.__getattr__(self, attr)
-		except AttributeError:
-			#print "Attribute ",attr," does not exist for this stream"
-			return "";
+		return PA_object.__getattr__(self, attr)
+
 # internal representation of a sink
 class Port(PA_object):
 	keys = ["Name", "Description", "Priority"]

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -361,8 +361,11 @@ class Stream(PA_object):
 				return self._props["application.name"][:-1]
 			elif "device.description" in self._props:
 				return self._props["device.description"][:-1]
-		return PA_object.__getattr__(self, attr)
-
+		try:
+			return PA_object.__getattr__(self, attr)
+		except AttributeError:
+			#print "Attribute ",attr," does not exist for this stream"
+			return "";
 # internal representation of a sink
 class Port(PA_object):
 	keys = ["Name", "Description", "Priority"]

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -366,7 +366,11 @@ class Stream(PA_object):
 				return self._props["media.name"][:-1]
 			elif "device.description" in self._props:
 				return self._props["device.description"][:-1]
-		return PA_object.__getattr__(self, attr)
+		try:
+			return PA_object.__getattr__(self, attr)
+		except AttributeError as exception:
+			print exception
+			return None
 
 # internal representation of a sink
 class Port(PA_object):
@@ -380,7 +384,11 @@ class Port(PA_object):
 		if attr == "device":
 			return self.device
 		
-		return PA_object.__getattr__(self, attr)
+		try:
+			return PA_object.__getattr__(self, attr)
+		except AttributeError as exception:
+			print exception
+			return None
 
 # query PA for a list of sinks
 def get_state_sinks():

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -357,9 +357,9 @@ class Stream(PA_object):
 	
 	def __getattr__(self, attr):
 		if attr == "name" or attr == "Name":
-			if "application.name" in self._props
+			if "application.name" in self._props:
 				return self._props["application.name"][:-1]
-			else if "device.description" in self._props
+			else if "device.description" in self._props:
 				return self._props["device.description"][:-1]
 		return PA_object.__getattr__(self, attr)
 

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -59,10 +59,9 @@ class PADbusWrapper(object):
 		dbus_addr = False
 		while not dbus_addr:
 			try:
-				_sbus = dbus.SessionBus()
-				
 				dbus_addr = os.environ.get('PULSE_DBUS_SERVER')
 				if not dbus_addr:
+					_sbus = dbus.SessionBus()
 					dbus_addr = _sbus.get_object('org.PulseAudio1', '/org/pulseaudio/server_lookup1').Get('org.PulseAudio.ServerLookup1', 'Address', dbus_interface='org.freedesktop.DBus.Properties')
 			
 			except dbus.exceptions.DBusException as exception:

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -357,9 +357,12 @@ class Stream(PA_object):
 	
 	def __getattr__(self, attr):
 		if attr == "name" or attr == "Name":
-			return self._props["application.name"][:-1]
-		
-		return PA_object.__getattr__(self, attr)
+			if "application.name" in self._props
+				return self._props["application.name"][:-1]
+			else if "device.description" in self._props
+				return self._props["device.description"][:-1]
+			else
+				return "Unknown"
 
 # internal representation of a sink
 class Port(PA_object):

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -357,8 +357,11 @@ class Stream(PA_object):
 	
 	def __getattr__(self, attr):
 		if attr == "name" or attr == "Name":
-			return self._props["application.name"][:-1]
-		
+			try:
+				return self._props["application.name"][:-1]
+			except KeyError:
+				return PA_object.__getattr__(self, attr)
+				
 		return PA_object.__getattr__(self, attr)
 
 # internal representation of a sink

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -359,7 +359,7 @@ class Stream(PA_object):
 		if attr == "name" or attr == "Name":
 			if "application.name" in self._props:
 				return self._props["application.name"][:-1]
-			else if "device.description" in self._props:
+			elif "device.description" in self._props:
 				return self._props["device.description"][:-1]
 		return PA_object.__getattr__(self, attr)
 

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -130,8 +130,11 @@ class PADbusWrapper(object):
 		return pstreams
 	
 	def get_stream_attr(self, stream, attr):
-		return dbus2str(stream.Get('org.PulseAudio.Core1.Stream', attr))
-	
+		try:
+			return dbus2str(stream.Get('org.PulseAudio.Core1.Stream', attr))
+		except dbus.exceptions.DBusException:
+			raise AttributeError
+
 	def move_stream2sink(self, stream, sink):
 		move = stream.get_dbus_method('Move', 'org.PulseAudio.Core1.Stream')
 		

--- a/mplugd/plugins/pi_pulseaudio.py
+++ b/mplugd/plugins/pi_pulseaudio.py
@@ -362,6 +362,8 @@ class Stream(PA_object):
 		if attr == "name" or attr == "Name":
 			if "application.name" in self._props:
 				return self._props["application.name"][:-1]
+			elif "media.name" in self._props:
+				return self._props["media.name"][:-1]
 			elif "device.description" in self._props:
 				return self._props["device.description"][:-1]
 		return PA_object.__getattr__(self, attr)


### PR DESCRIPTION
I've made a few small changes to enable Pulseaudio support with a system daemon (without X running) and also to clean up a number of exceptions when using bluetooth source support in Pulseaudio. There seems to be no differentiation between application / client streams and device streams, so a number of assumptions weren't quite right. This doesn't correct all of that - the best choice would probably be to completely separate out applications and non-application streams, but these changes at least stop any crashes, and should still work fine with non-application streams.
